### PR TITLE
Update to a supported version of the Google DFA Reporting API

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ app.post('/reports', function (req, res) {
 
   oauth2client.setCredentials(req.body);
   google.options({auth: oauth2client});
-  dfaReporting = google.dfareporting('v2.3');
+  dfaReporting = google.dfareporting('v2.6');
 
   console.log('Reports request received.');
 
@@ -156,7 +156,7 @@ app.post('/data', function (req, res) {
 
       oauth2client.setCredentials(req.body.auth);
       google.options({auth: oauth2client});
-      dfaReporting = google.dfareporting('v2.3');
+      dfaReporting = google.dfareporting('v2.6');
 
       dfaReporting.reports.run({
         profileId: req.body.profileId,
@@ -215,7 +215,7 @@ app._getColumns = function getColumns(opts, callback) {
 
   oauth2client.setCredentials(opts.auth);
   google.options({auth: oauth2client});
-  dfaReporting = google.dfareporting('v2.3');
+  dfaReporting = google.dfareporting('v2.6');
 
   dfaReporting.reports.get({
     profileId: opts.profileId,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "csv": "^0.4.6",
     "event-stream": "^3.3.2",
     "express": "^4.13.3",
-    "googleapis": "^2.1.6",
+    "googleapis": "^12.4.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "~0.5",


### PR DESCRIPTION
Moving from DFA Reporting API v2.3 (no longer supported) to v2.6 (latest supported version as of 28 days ago).

Closes #3 
May be related to #4